### PR TITLE
Use wstring_view

### DIFF
--- a/src/native_text.hpp
+++ b/src/native_text.hpp
@@ -82,7 +82,7 @@ namespace quickbook
             typedef std::wostream base_ostream;
             typedef std::wios base_ios;
             typedef std::wstring string;
-            typedef boost::wstring_ref string_ref;
+            typedef boost::wstring_view string_ref;
 #else
             typedef std::ostream base_ostream;
             typedef std::ios base_ios;


### PR DESCRIPTION
This fixes compilation under MSVC, where `QUICKBOOK_WIDE_STREAMS==1`.