### PR TITLE
Fix bash paths in shebangs

### DIFF
--- a/build/publish-docs
+++ b/build/publish-docs
@@ -6,7 +6,8 @@
 #   http://www.boost.org/LICENSE_1_0.txt)
 #==============================================================================
 
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 cd $(dirname $0)
 cd ..

--- a/extra/katepart/install.sh
+++ b/extra/katepart/install.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 # boost::hs installer
 #


### PR DESCRIPTION
"/bin/bash" is a Linuxism.  "/usr/bin/env bash" is portable.