### PR TITLE
Disable `quick` target when <cxxstd>03

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -167,5 +167,5 @@ test-suite quickbook.test :
     ;
 
 # for `b2 quick` in status
-alias quick : ../src//quickbook ;
+alias quick : ../src//quickbook : <cxxstd>03:<build>no ;
 explicit quick ;


### PR DESCRIPTION
Was curious what would happen if I push to an already-merged PR branch. Well, nothing happened. :-)