### PR TITLE
Use SOURCE_DATE_EPOCH for the last revision time

### DIFF
--- a/src/quickbook.cpp
+++ b/src/quickbook.cpp
@@ -466,7 +466,11 @@ int main(int argc, char* argv[])
             quickbook::debug_mode = true;
         }
         else {
-            time_t t = std::time(0);
+            time_t t;
+            if (getenv("SOURCE_DATE_EPOCH"))
+                t = strtol(getenv("SOURCE_DATE_EPOCH"), nullptr, 10);
+            else
+                t = std::time(0);
             static tm lt = *localtime(&t);
             static tm gmt = *gmtime(&t);
             quickbook::current_time = &lt;


### PR DESCRIPTION
When the environmental variable SOURCE_DATE_EPOCH is set, use it as the date for the last modification of the source instead of the current time. (See: https://reproducible-builds.org/specs/source-date-epoch/)