### PR TITLE
Throw glob_error value instead of new'ed pointer

### DIFF
--- a/src/glob.cpp
+++ b/src/glob.cpp
@@ -184,7 +184,7 @@ namespace quickbook
             switch (*pattern_it) {
             case '*':
                 assert(false);
-                throw new glob_error("Internal error");
+                throw glob_error("Internal error");
             case '[':
                 if (!match_range(pattern_it, pattern_end, *filename_it))
                     return false;


### PR DESCRIPTION
I'm pretty sure this was just a small typo style mistake.