### PR TITLE
collector: Initialize `default_` before referencing it

### DIFF
--- a/src/collector.hpp
+++ b/src/collector.hpp
@@ -75,9 +75,9 @@ namespace quickbook
 
       private:
         std::stack<string_stream> streams;
+        string_stream default_;
         boost::reference_wrapper<string_stream> main;
         boost::reference_wrapper<string_stream> top;
-        string_stream default_;
     };
 
     template <typename T>


### PR DESCRIPTION
`quickbook::collector::collector()` causes a warning:
> warning: member 'quickbook::collector::default_' is used uninitialized [-Wuninitialized]
>   33 |     collector::collector() : main(default_), top(default_) {}

Fix by moving it before `main`&`top` such that it is at least constructed before being referenced (main/top are reference_wrappers, so no actual use is done)