### PR TITLE
Avoid using templated initial_path()

### DIFF
--- a/src/quickbook.cpp
+++ b/src/quickbook.cpp
@@ -280,7 +280,7 @@ int main(int argc, char* argv[])
 
         // First thing, the filesystem should record the current working
         // directory.
-        fs::initial_path<fs::path>();
+        fs::initial_path();
 
         // Various initialisation methods
         quickbook::detail::initialise_output();


### PR DESCRIPTION
Templated initial_path() overloads have been marked as deprecated in Boost.Filesystem v3 and removed in v4. Use the non-templated equivalent.